### PR TITLE
Use the correct name of the binary encoding selector

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ function swarmHashBlock (data, totalLength) {
   tmp.writeUIntLE(totalLength, 0, 6)
   hash.update(tmp)
   hash.update(data)
-  return Buffer.from(hash.digest('bin'), 'binary')
+  return Buffer.from(hash.digest('binary'), 'binary')
 }
 
 function swarmHash (data) {


### PR DESCRIPTION
The library currently calls `hash.digest('bin')` which crashes `browserify-sha3`.

`hash` is either the C implementation which comes from `sha3` package (when available) or the JS one from `browserify-sha3` otherwise. The latter clearly [expects the value to be `'binary'`, not `'bin'`](https://gitlab.com/mjbecze/browserify-sha3/-/blob/master/index.js). [Same for `sha3`](https://github.com/nodejs/node/blob/master/src/api/encoding.cc#L57-L62) but it's more lax and just assumes  `'binary'` when the encoding is not recognized.

I'm not sure how to write a test for this but I checked it manually and `'binary'` works with both.

### Error output
I got this in https://github.com/ethereum/solc-bin/pull/40. Apparently `sha3` must have failed to build in Travis and it fell back to `browserify-sha3`: https://travis-ci.org/github/ethereum/solc-bin/builds/744413140
```
Computing hashes of '/linux-amd64/solc-linux-amd64-v0.4.10+commit.f0d539ae'
/home/travis/build/ethereum/solc-bin/node_modules/browserify-sha3/index.js:32
    throw new Error('Unsupported encoding for digest: ' + encoding)
          ^

Error: Unsupported encoding for digest: bin
    at hash.digest (/home/travis/build/ethereum/solc-bin/node_modules/browserify-sha3/index.js:32:11)
    at swarmHashBlock (/home/travis/build/ethereum/solc-bin/node_modules/swarmhash/index.js:11:27)
    at swarmHash (/home/travis/build/ethereum/solc-bin/node_modules/swarmhash/index.js:18:12)
    at swarmHash (/home/travis/build/ethereum/solc-bin/node_modules/swarmhash/index.js:29:21)
    at swarmHash (/home/travis/build/ethereum/solc-bin/node_modules/swarmhash/index.js:29:21)
    at makeEntry (/home/travis/build/ethereum/solc-bin/update:143:19)
    at async /home/travis/build/ethereum/solc-bin/update:193:43
    at async Promise.all (index 0)
    at async /home/travis/build/ethereum/solc-bin/update:179:25
```